### PR TITLE
feat: add get active orders by table id router

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -42,8 +42,10 @@ func SetupRoutes(r *gin.Engine, client *db.MongoClient) {
 	orderGroup := r.Group("/api/v1/order")
 	{
 		orderGroup.POST("/:tableID", order.CreateOrder(client))
+		orderGroup.GET("/active/:tableID", order.GetActiveOrdersByTableID(client))
 		orderGroup.GET(
 			"",
+			auth.Authenticate([]string{"admin", "cashier", "waiter"}),
 			order.GetOrders(client),
 		)
 		orderGroup.PATCH(

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -327,7 +327,7 @@ func DeleteUser(client db.IMongoClient) gin.HandlerFunc {
 // @Failure 500 {object} map[string]string "Internal server error"
 func GetUserById(client db.IMongoClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		id := c.Param("id")
+ 		id := c.Param("id")
 		if id == "" {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error": "Invalid ID!",
@@ -356,7 +356,7 @@ func GetUserById(client db.IMongoClient) gin.HandlerFunc {
 		// Get context from the request
 		ctx := c.Request.Context()
 
-		// Delete user from database
+		// Get user from database
 		result := collection.FindOne(ctx, bson.D{{Key: "_id", Value: docID}})
 
 		var user userResponse


### PR DESCRIPTION
Orders route was not protected so I made this route to check the table orders and protect the actual orders route so users cannot get all the orders only can get the specific tables active order.